### PR TITLE
Upgrading Setup-Python

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,13 +4,16 @@ inputs:
     version:
         required: true
         description: "The version of Ansible to install."
+    python-version:
+        required: false
+        description: "If you wish to override the default version of python."
 runs:
     using: "composite"
     steps:
         - name: "Install Python"
           uses: actions/setup-python@v5
           with:
-              python-version: "3.12"
+              python-version: ${{ inputs.python-version }}
 
         - name: "Cache python packages"
           uses: actions/cache@v4
@@ -18,7 +21,7 @@ runs:
               path: ~/.cache/pip
               key: ${{ runner.os }}-${{ inputs.version }}
 
-        - name: "Install packages"
+        - name: "Install Ansible"
           shell: bash
           run: |
-              python -m pip install ansible==${{ inputs.version}}
+              python -m pip install ansible==${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ runs:
     using: "composite"
     steps:
         - name: "Install Python"
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.12"
 


### PR DESCRIPTION
Using setup-python@v5, which seems to work without issues.

Also allowing the python version to be specified, although it looks like leaving it blank will result in an annotation on the build, but ... does allow whoever's using the action to select a version of Python, including using a .python-version file? You should look at that part to see if you're ok with it. ;)